### PR TITLE
Release 0.27.1 (try 2)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -28,6 +28,8 @@ requirements:
     - requests >=2.18.0,<3.0.0dev
     - setuptools >=34.0.0
     - six >=1.10.0
+    # Backport of concurrent.futures for Python < 3.2.
+    - futures >=3.0.0  # [py2k]
 
 test:
   imports:


### PR DESCRIPTION
Adds futures from extras_require so this package works on Python versions before concurrent.futures was introduced.